### PR TITLE
Enable ppc64le

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import fnmatch
+import platform
 import hashlib
 import os
 import sys
@@ -125,6 +126,7 @@ config['libdevice_versions'] = ['10']
 
 config['linux'] = {
     'blob': 'cuda_10.2.89_440.33.01_rhel6.run',
+    'ppc64le_blob': 'cuda_10.2.89_440.33.01_linux_ppc64le.run',
     'embedded_blob': 'cuda-linux.10.2.89-27506705.run',
     'patches': [],
     # need globs to handle symlinks
@@ -399,6 +401,15 @@ class WindowsExtractor(Extractor):
 class LinuxExtractor(Extractor):
     """The linux extractor
     """
+
+    def __init__(self, version, ver_config, plt_config):
+        if platform.machine() == 'ppc64le':
+            if plt_config.get('ppc64le_blob') is not None:
+                plt_config['blob'] = plt_config['ppc64le_blob']
+            else:
+                raise RuntimeError('ppc64le not supported for %s' % version)
+
+        super(LinuxExtractor, self).__init__(version, ver_config, plt_config)
 
     def copy(self, *args):
         basepath = args[0]

--- a/build.py
+++ b/build.py
@@ -415,11 +415,15 @@ class LinuxExtractor(Extractor):
 
     def copy(self, *args):
         basepath = args[0]
+        if self.embedded_blob is not None:
+            cudapath=''
+        else:
+            cudapath='cuda-toolkit'
         self.copy_files(
             cuda_lib_dir=os.path.join(
-                basepath, 'lib64'), nvvm_lib_dir=os.path.join(
-                basepath, 'nvvm', 'lib64'), libdevice_lib_dir=os.path.join(
-                basepath, 'nvvm', 'libdevice'))
+                basepath, cudapath, 'lib64'), nvvm_lib_dir=os.path.join(
+                basepath, cudapath, 'nvvm', 'lib64'), libdevice_lib_dir=os.path.join(
+                basepath, cudapath, 'nvvm', 'libdevice'))
 
     def extract(self):
         runfile = self.config_blob
@@ -437,7 +441,7 @@ class LinuxExtractor(Extractor):
                     check_call(cmd)
             else:
                 cmd = [os.path.join(self.src_dir, runfile),
-                       '--toolkitpath', tmpd, '--toolkit', '--silent']
+                       '--extract=%s' % (tmpd), '--toolkit', '--silent']
                 check_call(cmd)
             for p in patches:
                 os.chmod(p, 0o777)

--- a/build.py
+++ b/build.py
@@ -128,6 +128,7 @@ config['linux'] = {
     'blob': 'cuda_10.2.89_440.33.01_rhel6.run',
     'ppc64le_blob': 'cuda_10.2.89_440.33.01_linux_ppc64le.run',
     'embedded_blob': 'cuda-linux.10.2.89-27506705.run',
+    'ppc64le_embedded_blob': None,
     'patches': [],
     # need globs to handle symlinks
     'cuda_lib_fmt': 'lib{0}.so*',
@@ -408,6 +409,7 @@ class LinuxExtractor(Extractor):
                 plt_config['blob'] = plt_config['ppc64le_blob']
             else:
                 raise RuntimeError('ppc64le not supported for %s' % version)
+            plt_config['embedded_blob'] = plt_config['ppc64le_embedded_blob']
 
         super(LinuxExtractor, self).__init__(version, ver_config, plt_config)
 

--- a/build.py
+++ b/build.py
@@ -440,8 +440,16 @@ class LinuxExtractor(Extractor):
                            '-prefix', tmpd, '-noprompt', '--nox11']
                     check_call(cmd)
             else:
+                # Nvidia's RHEL7 based runfiles don't use embedded runfiles
+                # Once the toolkit is extracted, it ends up in a directory called "cuda-toolkit'
+                # the --extract runfile command is used because letting the runfile do an "install" 
+                # results in attempted installs of .pc and doc files into standard Linux locations, 
+                # which is not what we want.
+                # The "--override" runfile command to disable the compiler check since we are not
+                # installing the driver here.
+
                 cmd = [os.path.join(self.src_dir, runfile),
-                       '--extract=%s' % (tmpd), '--toolkit', '--silent']
+                       '--extract=%s' % (tmpd), '--toolkit', '--silent', '--override']
                 check_call(cmd)
             for p in patches:
                 os.chmod(p, 0o777)


### PR DESCRIPTION
This PR adds support for building recent cudatoolkit versions for ppc64le.

- Nvidia's RHEL7 based runfiles don't use embedded runfiles
- Once the toolkit is extracted, it ends up in a directory called "cuda-toolkit'
- the `--extract` runfile command is used because letting the runfile do an "install" results in attempted installs of .pc and doc files into standard Linux locations, which is not what we want.

https://github.com/AnacondaRecipes/cudatoolkit-feedstock/issues/4