### PR TITLE
CUDA 11 RC support

### DIFF
--- a/build.py
+++ b/build.py
@@ -140,7 +140,7 @@ config['linux'] = {
 
 config['windows'] = {'blob': 'cuda_11.0.1_451.22_win10.exe',
                    'patches': [],
-                   'cuda_lib_fmt': '{0}64_10*.dll',
+                   'cuda_lib_fmt': '{0}64_1*.dll',
                    'cuda_static_lib_fmt': '{0}.lib',
                    'nvtoolsext_fmt': '{0}64_1.dll',
                    'nvvm_lib_fmt': '{0}64_33_0.dll',

--- a/build.py
+++ b/build.py
@@ -118,8 +118,7 @@ config['cuda_libraries'] = [
     'nvrtc-builtins',
 ]
 config['cuda_static_libraries'] = [
-    'cudadevrt',
-    'culibos'
+    'cudadevrt'
 ]
 # accinj64 is only available on linux
 if sys.platform.startswith('linux'):

--- a/build.py
+++ b/build.py
@@ -89,13 +89,16 @@ config['installers_url_ext'] = 'local_installers/'
 config['patch_url_ext'] = ''
 config['md5_url'] = f"{config['base_url']}/docs/sidebar/md5sum.txt"
 config['cuda_libraries'] = [
+    'accinj64',
     'cublas',
     'cublasLt',
     'cudart',
     'cufft',
     'cufftw',
+    'cuinj64',
     'curand',
     'cusolver',
+    'cusolverMg',
     'cusparse',
     'nppc',
     'nppial',
@@ -112,11 +115,13 @@ config['cuda_libraries'] = [
     'nvToolsExt',
     'nvblas',
     'nvgraph',
+    'nvidia-ml',
     'nvrtc',
     'nvrtc-builtins',
 ]
 config['cuda_static_libraries'] = [
-    'cudadevrt'
+    'cudadevrt',
+    'culibos'
 ]
 # nvjpeg is only available on linux
 if sys.platform.startswith('linux'):

--- a/build.py
+++ b/build.py
@@ -114,7 +114,6 @@ config['cuda_libraries'] = [
     'npps',
     'nvToolsExt',
     'nvblas',
-    'nvgraph',
     'nvjpeg',
     'nvidia-ml',
     'nvrtc',

--- a/build.py
+++ b/build.py
@@ -424,7 +424,7 @@ class LinuxExtractor(Extractor):
                     check_call(cmd)
             else:
                 cmd = [os.path.join(self.src_dir, runfile),
-                       '--toolkitpath=%s' % (tmpd, ), '--toolkit', '--silent', '--override']
+                       '--toolkitpath=%s' % (tmpd, ), '--toolkit', '--silent', '--override', '--nox11']
                 check_call(cmd)
             for p in patches:
                 os.chmod(p, 0o777)

--- a/build.py
+++ b/build.py
@@ -94,6 +94,7 @@ config['cuda_libraries'] = [
     'cudart',
     'cufft',
     'cufftw',
+    'cuinj64',
     'curand',
     'cusolver',
     'cusolverMg',
@@ -120,10 +121,9 @@ config['cuda_static_libraries'] = [
     'cudadevrt',
     'culibos'
 ]
-# accinj64 & cuinj64 are only available on linux
+# accinj64 is only available on linux
 if sys.platform.startswith('linux'):
     config['cuda_libraries'].append('accinj64')
-    config['cuda_libraries'].append('cuinj64')
 config['libdevice_versions'] = ['11']
 
 config['linux'] = {

--- a/build.py
+++ b/build.py
@@ -79,12 +79,12 @@ def md5(fname):
 
 
 #######################
-### CUDA 10.2 setup ###
+### CUDA 11.0 setup ###
 #######################
 
-maj_min = '10.2'
+maj_min = '11.0'
 config = {}
-config['base_url'] = f"http://developer.download.nvidia.com/compute/cuda/{maj_min}/Prod/"
+config['base_url'] = f"http://developer.download.nvidia.com/compute/cuda/11.0.1/"
 config['installers_url_ext'] = 'local_installers/'
 config['patch_url_ext'] = ''
 config['md5_url'] = f"{config['base_url']}/docs/sidebar/md5sum.txt"
@@ -121,11 +121,11 @@ config['cuda_static_libraries'] = [
 # nvjpeg is only available on linux
 if sys.platform.startswith('linux'):
     config['cuda_libraries'].append('nvjpeg')
-config['libdevice_versions'] = ['10']
+config['libdevice_versions'] = ['11']
 
 config['linux'] = {
-    'blob': 'cuda_10.2.89_440.33.01_rhel6.run',
-    'embedded_blob': 'cuda-linux.10.2.89-27506705.run',
+    'blob': 'cuda_11.0.1_450.36.06_linux.run',
+    'embedded_blob': 'NVIDIA-Linux-x86_64-450.36.06.run',
     'patches': [],
     # need globs to handle symlinks
     'cuda_lib_fmt': 'lib{0}.so*',
@@ -135,7 +135,7 @@ config['linux'] = {
     'libdevice_lib_fmt': 'libdevice.{0}.bc'
 }
 
-config['windows'] = {'blob': 'cuda_10.2.89_441.22_windows.exe',
+config['windows'] = {'blob': 'cuda_11.0.1_451.22_win10.exe',
                    'patches': [],
                    'cuda_lib_fmt': '{0}64_10*.dll',
                    'cuda_static_lib_fmt': '{0}.lib',

--- a/build.py
+++ b/build.py
@@ -115,6 +115,7 @@ config['cuda_libraries'] = [
     'nvToolsExt',
     'nvblas',
     'nvgraph',
+    'nvjpeg',
     'nvidia-ml',
     'nvrtc',
     'nvrtc-builtins',
@@ -123,9 +124,6 @@ config['cuda_static_libraries'] = [
     'cudadevrt',
     'culibos'
 ]
-# nvjpeg is only available on linux
-if sys.platform.startswith('linux'):
-    config['cuda_libraries'].append('nvjpeg')
 config['libdevice_versions'] = ['11']
 
 config['linux'] = {

--- a/build.py
+++ b/build.py
@@ -132,7 +132,7 @@ config['linux'] = {
     'cuda_static_lib_fmt': 'lib{0}.a',
     'nvtoolsext_fmt': 'lib{0}.so*',
     'nvvm_lib_fmt': 'lib{0}.so*',
-    'libdevice_lib_fmt': 'libdevice.{0}.bc'
+    'libdevice_lib_fmt': 'libdevice.10.bc'
 }
 
 config['windows'] = {'blob': 'cuda_11.0.1_451.22_win10.exe',
@@ -141,7 +141,7 @@ config['windows'] = {'blob': 'cuda_11.0.1_451.22_win10.exe',
                    'cuda_static_lib_fmt': '{0}.lib',
                    'nvtoolsext_fmt': '{0}64_1.dll',
                    'nvvm_lib_fmt': '{0}64_33_0.dll',
-                   'libdevice_lib_fmt': 'libdevice.{0}.bc',
+                   'libdevice_lib_fmt': 'libdevice.10.bc',
                    'NvToolsExtPath' :
                        os.path.join('c:' + os.sep, 'Program Files',
                                     'NVIDIA Corporation', 'NVToolsExt', 'bin')

--- a/build.py
+++ b/build.py
@@ -127,7 +127,6 @@ config['libdevice_versions'] = ['11']
 
 config['linux'] = {
     'blob': 'cuda_11.0.1_450.36.06_linux.run',
-    'embedded_blob': 'NVIDIA-Linux-x86_64-450.36.06.run',
     'patches': [],
     # need globs to handle symlinks
     'cuda_lib_fmt': 'lib{0}.so*',

--- a/build.py
+++ b/build.py
@@ -89,13 +89,11 @@ config['installers_url_ext'] = 'local_installers/'
 config['patch_url_ext'] = ''
 config['md5_url'] = f"{config['base_url']}/docs/sidebar/md5sum.txt"
 config['cuda_libraries'] = [
-    'accinj64',
     'cublas',
     'cublasLt',
     'cudart',
     'cufft',
     'cufftw',
-    'cuinj64',
     'curand',
     'cusolver',
     'cusolverMg',
@@ -122,6 +120,10 @@ config['cuda_static_libraries'] = [
     'cudadevrt',
     'culibos'
 ]
+# accinj64 & cuinj64 are only available on linux
+if sys.platform.startswith('linux'):
+    config['cuda_libraries'].append('accinj64')
+    config['cuda_libraries'].append('cuinj64')
 config['libdevice_versions'] = ['11']
 
 config['linux'] = {

--- a/build.py
+++ b/build.py
@@ -425,7 +425,7 @@ class LinuxExtractor(Extractor):
                     check_call(cmd)
             else:
                 cmd = [os.path.join(self.src_dir, runfile),
-                       '--toolkitpath', tmpd, '--toolkit', '--silent']
+                       '--toolkitpath=%s' % (tmpd, ), '--toolkit', '--silent']
                 check_call(cmd)
             for p in patches:
                 os.chmod(p, 0o777)

--- a/build.py
+++ b/build.py
@@ -425,7 +425,7 @@ class LinuxExtractor(Extractor):
                     check_call(cmd)
             else:
                 cmd = [os.path.join(self.src_dir, runfile),
-                       '--toolkitpath=%s' % (tmpd, ), '--toolkit', '--silent']
+                       '--toolkitpath=%s' % (tmpd, ), '--toolkit', '--silent', '--override']
                 check_call(cmd)
             for p in patches:
                 os.chmod(p, 0o777)

--- a/build.py
+++ b/build.py
@@ -103,7 +103,6 @@ config['cuda_libraries'] = [
     'nppc',
     'nppial',
     'nppicc',
-    'nppicom',
     'nppidei',
     'nppif',
     'nppig',

--- a/build.py
+++ b/build.py
@@ -113,7 +113,6 @@ config['cuda_libraries'] = [
     'nvToolsExt',
     'nvblas',
     'nvjpeg',
-    'nvidia-ml',
     'nvrtc',
     'nvrtc-builtins',
 ]

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,7 +1,7 @@
 package:
    name: cudatoolkit
    # match the package version to the libcudart.so version
-   version: 10.2.89
+   version: 11.0.171
 
 source:
     path: .

--- a/meta.yaml
+++ b/meta.yaml
@@ -11,7 +11,7 @@ source:
 # downloaded the installer
 
 build:
-  number: 1
+  number: 0
   script_env:
     - NVTOOLSEXT_INSTALL_PATH
     - DEBUG_INSTALLER_PATH


### PR DESCRIPTION
## Overview
Built this for linux, with a test package [here](https://anaconda.org/nvidia/repo/files?type=any&label=testing) with its associated [job run](https://gpuci.gpuopenanalytics.com/job/nvidia/job/conda/job/cudatoolkit-builder/15/consoleFull)

I did a local install on a windows box to update and confirm the libs/versioning information. That has been updated, **but** I need someone else to run this conda build on a windows machine and verify it works.

## Notable changes/findings
- Installer has changed again on linux side, unsure about windows
  - Updated script to work with new installer
- Noticed mismatched library versions in both linux and windows
  - My guess this is due to the RC nature
  - Found some libraries still with version `10`, others have correct `11`; noticed at least one library with `110` as a version number
- `nvjpeg` is on windows as well now

## TODO
- [x] libs/versions updated for linux
- [x] package built for linux
- [x] libs/versions updated for windows
- [ ] package built for windows - ***need help***

cc @jjhelmus @seibert @jakirkham @gmarkall