### PR TITLE
ENH Add CUDA 11.1 Support

### DIFF
--- a/build.py
+++ b/build.py
@@ -79,13 +79,13 @@ def md5(fname):
 # defined install directory) and the DLL will be taken from that location.
 
 
-###########################################
-### CUDA 11.0 Update 1 setup (Aug 2020) ###
-###########################################
+##################################
+### CUDA 11.1 setup (Oct 2020) ###
+##################################
 
-maj_min = '11.0'
+maj_min = '11.1'
 config = {}
-config['base_url'] = f"http://developer.download.nvidia.com/compute/cuda/11.0.3/"
+config['base_url'] = f"http://developer.download.nvidia.com/compute/cuda/11.1.0/"
 config['installers_url_ext'] = 'local_installers/'
 config['patch_url_ext'] = ''
 config['md5_url'] = f"{config['base_url']}/docs/sidebar/md5sum.txt"
@@ -129,9 +129,9 @@ if sys.platform.startswith('windows'):
 config['libdevice_versions'] = ['11']
 
 config['linux'] = {
-    'blob': 'cuda_11.0.3_450.51.06_linux.run',
-    'ppc64le_blob': 'cuda_11.0.3_450.51.06_linux_ppc64le.run',
-    # CUDA 11 installer has channed, there are no embedded blobs
+    'blob': 'cuda_11.1.0_455.23.05_linux.run',
+    'ppc64le_blob': 'cuda_11.1.0_455.23.05_linux_ppc64le.run',
+    # CUDA 11 installer has changed, there are no embedded blobs
     'embedded_blob': None,
     'ppc64le_embedded_blob': None,
     'patches': [],
@@ -143,7 +143,7 @@ config['linux'] = {
     'libdevice_lib_fmt': 'libdevice.10.bc'
 }
 
-config['windows'] = {'blob': 'cuda_11.0.3_451.82_win10.exe',
+config['windows'] = {'blob': 'cuda_11.1.0_456.43_win10.exe',
                    'patches': [],
                    'cuda_lib_fmt': '{0}64_1*.dll',
                    'cuda_static_lib_fmt': '{0}.lib',

--- a/meta.yaml
+++ b/meta.yaml
@@ -32,8 +32,8 @@ requirements:
     - tqdm
     # for run_exports
     - {{ compiler('cxx') }}
-  run_constrained:
-    - __cuda >=11.0
+#  run_constrained:
+#    - __cuda >=11.1
 
 test:
   requires:

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,7 +1,7 @@
 package:
    name: cudatoolkit
    # match the package version to the libcudart.so version
-   version: 11.0.221
+   version: 11.1.74
 
 source:
     path: .

--- a/meta.yaml
+++ b/meta.yaml
@@ -32,8 +32,8 @@ requirements:
     - tqdm
     # for run_exports
     - {{ compiler('cxx') }}
-#  run_constrained:
-#    - __cuda >=11.1
+  run_constrained:
+    - __cuda >=11.1
 
 test:
   requires:


### PR DESCRIPTION
Test linux pkg w/o `run_constrained` - https://anaconda.org/nvidia/cudatoolkit/files?version=11.1.74

This PR has `run_constrained` updated to `11.1`, we don't use this for CTK in the `nvidia` channel due to problems it causes for conda running in docker images like `nvidia/cuda`

Not tested on Windows and may have the bug #12. I do not have time to debug that issue, but wanted to contribute this to get this update moving

cc @jakirkham @gmarkall @kkraus14