### PR TITLE
Ensure the x64 cudadevrt.lib gets packaged (Fixes #12)

### DIFF
--- a/build.py
+++ b/build.py
@@ -377,11 +377,12 @@ class WindowsExtractor(Extractor):
                                     os.path.join(path, filename),
                                     store)
                         for filename in fnmatch.filter(files, "*.lib"):
-                            if not Path(os.path.join(
-                                    store, filename)).is_file():
-                                shutil.copy(
-                                    os.path.join(path, filename),
-                                    store)
+                            if path.endswith('x64'):
+                                if not Path(os.path.join(
+                                        store, filename)).is_file():
+                                    shutil.copy(
+                                        os.path.join(path, filename),
+                                        store)
                         for filename in fnmatch.filter(files, "*.bc"):
                             if not Path(os.path.join(
                                     store, filename)).is_file():


### PR DESCRIPTION
There are two versions of cudadevrt.lib in the toolkit installer - an x64 version and a Win32 version. The Win32 version was getting  picked up by the extractor, but the x64 version is required. This commit ensures that x64 is in the path of cudadevrt.lib before copying, so that the correct version is packaged.