### PR TITLE
Include ptxas in cudatoolkit package

### DIFF
--- a/build.py
+++ b/build.py
@@ -327,6 +327,7 @@ class Extractor(object):
         # TensorFlow XLA
         bin_dir = os.path.join(self.prefix, 'bin')
         os.makedirs(bin_dir, exist_ok=True)
+        print('copying %s to %s' % (os.path.join(basepath_dir, 'bin', 'ptxas'), bin_dir))
         shutil.copy(os.path.join(basepath_dir, 'bin', 'ptxas'), bin_dir)
 
         # libdevice.10.bc should also reside in its original
@@ -334,6 +335,7 @@ class Extractor(object):
         nvvm_libdevice_dir = os.path.join(self.prefix, 'nvvm', 'libdevice')
         os.makedirs(nvvm_libdevice_dir, exist_ok=True)
         for libversion in self.libdevice_versions:
+            print('copying %s to %s' % (os.path.join(basepath_dir, 'nvvm', 'libdevice', self.libdevice_lib_fmt.format(libversion)), nvvm_libdevice_dir))
             shutil.copy(os.path.join(basepath_dir, 'nvvm', 'libdevice', self.libdevice_lib_fmt.format(libversion)), nvvm_libdevice_dir)
         
 


### PR DESCRIPTION
It was discovered that XLA does not work with the latest TensorFlow GPU builds:
https://github.com/AnacondaRecipes/tensorflow_recipes/issues/24#issuecomment-797085401

This is because XLA requires the ptxas compiler and libdevice.10.bc.

This PR has two changes to the cudatoolkit package to fix XLA:

- the libdevice.10.bc package is in the wrong location for XLA. It's shipped in $CONDA_HOME/lib when it should be in  `$CONDA_HOME/nvvm/libdevice/`  so this PR copies it to this location (and keeps it in /lib too in case some things need it there)

- the `ptxas` binary, which is used by the XLA compiler, is not included in the package at all currently so this PR add it into `$CONDA_HOME/bin`

Unfortunately, this feedstock doesn't have any branches for older cuda versions, so this PR is only against the latest (11.0).